### PR TITLE
Add manual seeding controls to developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,28 +62,15 @@ A minimal expense-tracking app for two people (Karam + Kazi) built with React Na
 
 #### Database Seed Data
 
-The app can seed sample expenses for testing in development mode. To enable seeding:
+The developer tools screen now exposes a dedicated **Seed data** button for quickly loading realistic fixtures during development:
 
-1. **Set the environment variable**
+1. Launch the dev client with `npx expo start`.
+2. Navigate to **Settings → Developer Tools → Database**.
+3. Tap **Seed data** and confirm the prompt.
 
-   Create or edit `.env` in the project root:
+The script inserts a spread of expenses across the past several months and refreshes the current month view automatically. It leaves your configured payers and categories untouched so you can iterate on those independently. If expenses already exist, the seeding step is skipped and you'll be prompted to reset first if you want a clean slate.
 
-   ```env
-   EXPO_PUBLIC_SEED=1
-   ```
-
-2. **Start the development server**
-
-   ```bash
-   npx expo start
-   ```
-
-   Seed data will only be inserted when both conditions are met:
-
-   - Running in development mode (`__DEV__ === true`)
-   - `EXPO_PUBLIC_SEED` environment variable is set to `'1'`
-
-**Important**: Seed data will NOT run or ship in production builds. The seed logic is dynamically imported only in development, ensuring it's tree-shaken in production bundles.
+Use the existing **Reset Database** action to clear everything before seeding again.
 
 #### Database Schema
 

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -16,12 +16,6 @@ export default function RootLayout() {
 
       // Load categories and payers into the settings store
       await loadSettings();
-
-      // Only seed in development when explicitly enabled
-      // if (__DEV__ && process.env.EXPO_PUBLIC_SEED === "1") {
-      //   const { seed } = await import("../src/dev/seed");
-      //   await seed(db);
-      // }
     };
 
     initializeApp().catch(console.error);

--- a/eas.json
+++ b/eas.json
@@ -3,8 +3,8 @@
     "version": ">= 9.0.0"
   },
   "build": {
-    "preview": { "android": { "buildType": "apk" }, "env": { "EXPO_PUBLIC_SEED": "0" } },
-    "internal": { "env": { "EXPO_PUBLIC_SEED": "0" } },  // AAB for Play Internal testing
+    "preview": { "android": { "buildType": "apk" } },
+    "internal": {},  // AAB for Play Internal testing
     "development": {
       "developmentClient": true,
       "distribution": "internal"


### PR DESCRIPTION
## Summary
- remove the legacy EXPO_PUBLIC_SEED code paths and expose a dedicated seeding control in the developer tools screen
- enrich the development seed script with multi-month fixtures while skipping when expenses already exist
- document the new workflow and drop the unused build-time environment variable

## Testing
- npm run lint *(fails: expo CLI is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e582a99a2483269a7ba564584e68c5