### PR TITLE
feat(web): add interactive month pickers and mobile bottom nav

### DIFF
--- a/apps/web/src/app/settings/categories/page.tsx
+++ b/apps/web/src/app/settings/categories/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { createClient } from "@/lib/supabase/client";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
@@ -61,22 +61,7 @@ export default function CategoriesPage() {
   const supabase = createClient();
   const router = useRouter();
 
-  useEffect(() => {
-    loadData();
-  }, []);
-
-  // Close picker when clicking outside
-  useEffect(() => {
-    function handleClickOutside(event: MouseEvent) {
-      if (pickerRef.current && !pickerRef.current.contains(event.target as Node)) {
-        setShowPicker(false);
-      }
-    }
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, []);
-
-  async function loadData() {
+  const loadData = useCallback(async () => {
     const {
       data: { user },
     } = await supabase.auth.getUser();
@@ -106,7 +91,22 @@ export default function CategoriesPage() {
 
     setCategories(categoriesData || []);
     setLoading(false);
-  }
+  }, [supabase, router]);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  // Close picker when clicking outside
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (pickerRef.current && !pickerRef.current.contains(event.target as Node)) {
+        setShowPicker(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
 
   async function handleAddCategory(e: React.FormEvent) {
     e.preventDefault();

--- a/apps/web/src/app/settings/payers/page.tsx
+++ b/apps/web/src/app/settings/payers/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { createClient } from "@/lib/supabase/client";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
@@ -20,11 +20,7 @@ export default function PayersPage() {
   const supabase = createClient();
   const router = useRouter();
 
-  useEffect(() => {
-    loadData();
-  }, []);
-
-  async function loadData() {
+  const loadData = useCallback(async () => {
     const {
       data: { user },
     } = await supabase.auth.getUser();
@@ -54,7 +50,11 @@ export default function PayersPage() {
 
     setPayers(payersData || []);
     setLoading(false);
-  }
+  }, [supabase, router]);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
 
   async function handleAddPayer(e: React.FormEvent) {
     e.preventDefault();

--- a/apps/web/src/app/setup/page.test.tsx
+++ b/apps/web/src/app/setup/page.test.tsx
@@ -23,6 +23,7 @@ describe("SetupPage", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     vi.mocked(useRouter).mockReturnValue({
       push: mockPush,
       refresh: mockRefresh,
@@ -31,6 +32,7 @@ describe("SetupPage", () => {
       data: { user: { user_metadata: { full_name: "Test User" } } },
     });
     mockSignOut.mockResolvedValue({ error: null });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     vi.mocked(createClient).mockReturnValue({
       rpc: mockRpc,
       auth: {
@@ -153,6 +155,7 @@ describe("SetupPage", () => {
     });
 
     it("shows loading state while creating", async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       let resolveRpc: (value: any) => void;
       mockRpc.mockReturnValue(
         new Promise((resolve) => {
@@ -261,6 +264,7 @@ describe("SetupPage", () => {
     });
 
     it("shows loading state while joining", async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       let resolveRpc: (value: any) => void;
       mockRpc.mockReturnValue(
         new Promise((resolve) => {

--- a/apps/web/src/components/add-expense-button.tsx
+++ b/apps/web/src/components/add-expense-button.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { createClient } from "@/lib/supabase/client";
 import type { CategoryRow, PayerRow } from "@expenses/shared";
 import { parseAmountInput, getTodayYYYYMMDD } from "@expenses/shared";
@@ -26,7 +26,7 @@ interface AddExpenseButtonProps {
   onAdded: () => void;
   forceOpen?: boolean;
   onClose?: () => void;
-  variant?: "fab" | "inline";
+  hideButton?: boolean;
 }
 
 export function AddExpenseButton({
@@ -36,19 +36,23 @@ export function AddExpenseButton({
   onAdded,
   forceOpen,
   onClose,
-  variant = "fab",
+  hideButton,
 }: AddExpenseButtonProps) {
-  const [isOpen, setIsOpen] = useState(false);
+  const [internalOpen, setInternalOpen] = useState(false);
 
-  // Sync with forceOpen prop
-  useEffect(() => {
-    if (forceOpen !== undefined) {
-      setIsOpen(forceOpen);
+  // Use forceOpen if provided, otherwise use internal state
+  const isOpen = forceOpen !== undefined ? forceOpen : internalOpen;
+
+  const handleOpen = () => {
+    if (forceOpen === undefined) {
+      setInternalOpen(true);
     }
-  }, [forceOpen]);
+  };
 
   const handleClose = () => {
-    setIsOpen(false);
+    if (forceOpen === undefined) {
+      setInternalOpen(false);
+    }
     setError(null);
     onClose?.();
   };
@@ -98,9 +102,8 @@ export function AddExpenseButton({
       setNote("");
       setDate(getTodayYYYYMMDD());
       setError(null);
-      setIsOpen(false);
+      handleClose();
       setLoading(false);
-      onClose?.();
       onAdded();
     } catch (err) {
       setError(
@@ -112,17 +115,9 @@ export function AddExpenseButton({
 
   return (
     <>
-      {variant === "fab" ? (
+      {!hideButton && (
         <button
-          onClick={() => setIsOpen(true)}
-          className="fixed bottom-6 right-6 w-14 h-14 bg-charcoal-text text-cream-bg rounded-full shadow-lg shadow-charcoal-text/20 hover:bg-charcoal-text/80 transition-colors flex items-center justify-center"
-          aria-label="Add expense"
-        >
-          <span className="material-symbols-outlined text-2xl">add</span>
-        </button>
-      ) : (
-        <button
-          onClick={() => setIsOpen(true)}
+          onClick={handleOpen}
           className="group flex items-center gap-2 bg-charcoal-text text-cream-bg px-5 py-2.5 rounded-full hover:bg-charcoal-text/80 transition-all shadow-lg shadow-charcoal-text/20"
         >
           <span className="material-symbols-outlined text-[20px] group-hover:rotate-90 transition-transform">

--- a/apps/web/src/components/bottom-nav.tsx
+++ b/apps/web/src/components/bottom-nav.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import Link from "next/link";
+
+type TabId = "dashboard" | "expenses" | "reports";
+
+interface BottomNavProps {
+  activeTab: TabId;
+}
+
+const tabs: { id: TabId; label: string; icon: string; href: string }[] = [
+  { id: "dashboard", label: "Dashboard", icon: "dashboard", href: "/" },
+  { id: "expenses", label: "Expenses", icon: "receipt_long", href: "/expenses" },
+  { id: "reports", label: "Reports", icon: "analytics", href: "/reports" },
+];
+
+export function BottomNav({ activeTab }: BottomNavProps) {
+  return (
+    <nav className="fixed bottom-0 left-0 right-0 bg-white border-t border-charcoal-text/5 md:hidden z-50">
+      <div className="flex items-center justify-around h-16 px-4 max-w-md mx-auto">
+        {tabs.map((tab) => {
+          const isActive = tab.id === activeTab;
+          return (
+            <Link
+              key={tab.id}
+              href={tab.href}
+              className={`flex flex-col items-center justify-center gap-0.5 flex-1 h-full transition-colors ${
+                isActive
+                  ? "text-charcoal-text"
+                  : "text-charcoal-text/40 hover:text-charcoal-text/60"
+              }`}
+            >
+              <span
+                className={`material-symbols-outlined text-[22px] ${
+                  isActive ? "font-semibold" : ""
+                }`}
+              >
+                {tab.icon}
+              </span>
+              <span className={`text-[10px] font-bold ${isActive ? "" : "font-medium"}`}>
+                {tab.label}
+              </span>
+            </Link>
+          );
+        })}
+      </div>
+    </nav>
+  );
+}

--- a/apps/web/src/components/expense-list-page.tsx
+++ b/apps/web/src/components/expense-list-page.tsx
@@ -20,6 +20,7 @@ import { MonthNavigator } from "./month-navigator";
 import { ExpenseList } from "./expense-list";
 import { TransactionSearch } from "./transaction-search";
 import { AddExpenseButton } from "./add-expense-button";
+import { BottomNav } from "./bottom-nav";
 
 interface ExpenseListPageProps {
   user: User;
@@ -119,7 +120,6 @@ export function ExpenseListPage({ user, profile }: ExpenseListPageProps) {
             payers={payers}
             householdId={profile.household_id!}
             onAdded={handleRefresh}
-            variant="inline"
           />
         </div>
 
@@ -146,6 +146,8 @@ export function ExpenseListPage({ user, profile }: ExpenseListPageProps) {
           />
         )}
       </main>
+
+      <BottomNav activeTab="expenses" />
     </div>
   );
 }

--- a/apps/web/src/components/month-picker-popover.tsx
+++ b/apps/web/src/components/month-picker-popover.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useState, useRef, useEffect, type ReactNode } from "react";
+import { getCurrentMonth, getPreviousMonth, formatMonthDisplay } from "@expenses/shared";
+
+interface MonthPickerPopoverProps {
+  currentMonth: string; // YYYY-MM
+  onSelectMonth: (month: string) => void;
+  trigger: ReactNode;
+  align?: "left" | "right" | "center";
+}
+
+function generateLast12Months(): string[] {
+  const months: string[] = [];
+  let month = getCurrentMonth();
+  for (let i = 0; i < 12; i++) {
+    months.push(month);
+    month = getPreviousMonth(month);
+  }
+  return months;
+}
+
+export function MonthPickerPopover({
+  currentMonth,
+  onSelectMonth,
+  trigger,
+  align = "left",
+}: MonthPickerPopoverProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const months = generateLast12Months();
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    }
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  const alignmentClass =
+    align === "left"
+      ? "left-0"
+      : align === "right"
+        ? "right-0"
+        : "left-1/2 -translate-x-1/2";
+
+  return (
+    <div className="relative" ref={dropdownRef}>
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="flex items-center gap-1 hover:bg-white/30 rounded-lg transition-colors cursor-pointer group"
+      >
+        {trigger}
+        <span className="material-symbols-outlined text-charcoal-text/40 text-[16px] group-hover:text-charcoal-text/60 transition-colors">
+          {isOpen ? "expand_less" : "expand_more"}
+        </span>
+      </button>
+
+      {isOpen && (
+        <div
+          className={`absolute ${alignmentClass} mt-2 bg-white rounded-xl shadow-lg border border-charcoal-text/5 overflow-hidden z-50 min-w-[180px] max-h-[320px] overflow-y-auto`}
+        >
+          {months.map((month) => (
+            <button
+              key={month}
+              onClick={() => {
+                onSelectMonth(month);
+                setIsOpen(false);
+              }}
+              className={`w-full px-4 py-2.5 text-left text-sm font-medium transition-colors ${
+                month === currentMonth
+                  ? "bg-pastel-mint text-charcoal-text font-bold"
+                  : "text-charcoal-text/70 hover:bg-cream-bg"
+              }`}
+            >
+              {formatMonthDisplay(month)}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/payer-balance-card.tsx
+++ b/apps/web/src/components/payer-balance-card.tsx
@@ -2,6 +2,7 @@ import { Card } from "./ui";
 import { formatAmount } from "@expenses/shared";
 import type { PayerBalance } from "@/lib/calculations/spending-calculations";
 import { calculateSettlement } from "@/lib/calculations/spending-calculations";
+import { MonthPickerPopover } from "./month-picker-popover";
 
 // Payer avatar colors
 const avatarColors = [
@@ -14,9 +15,11 @@ const avatarColors = [
 interface PayerBalanceCardProps {
   balances: PayerBalance[];
   monthLabel: string;
+  currentMonth?: string;
+  onMonthChange?: (month: string) => void;
 }
 
-export function PayerBalanceCard({ balances, monthLabel }: PayerBalanceCardProps) {
+export function PayerBalanceCard({ balances, monthLabel, currentMonth, onMonthChange }: PayerBalanceCardProps) {
   const settlement = calculateSettlement(balances);
   const grandTotal = balances.reduce((sum, b) => sum + b.paid, 0);
 
@@ -38,9 +41,22 @@ export function PayerBalanceCard({ balances, monthLabel }: PayerBalanceCardProps
     <Card variant="blue" hover>
       <div className="flex items-center justify-between mb-8">
         <h3 className="text-xl font-bold text-charcoal-text">Household Split</h3>
-        <div className="px-3 py-1 bg-white/50 rounded-full text-xs font-bold text-charcoal-text/60">
-          {monthLabel}
-        </div>
+        {currentMonth && onMonthChange ? (
+          <MonthPickerPopover
+            currentMonth={currentMonth}
+            onSelectMonth={onMonthChange}
+            align="right"
+            trigger={
+              <div className="px-3 py-1 bg-white/50 hover:bg-white/70 rounded-full text-xs font-bold text-charcoal-text/60 transition-colors">
+                {monthLabel}
+              </div>
+            }
+          />
+        ) : (
+          <div className="px-3 py-1 bg-white/50 rounded-full text-xs font-bold text-charcoal-text/60">
+            {monthLabel}
+          </div>
+        )}
       </div>
 
       {/* Payer cards */}

--- a/apps/web/src/components/summary-card.tsx
+++ b/apps/web/src/components/summary-card.tsx
@@ -2,18 +2,21 @@ import { Card } from "./ui";
 import type { MonthSummary, PayerRow } from "@expenses/shared";
 import { formatSEKParts } from "@expenses/shared";
 import type { MonthChange } from "@/lib/calculations/spending-calculations";
+import { MonthPickerPopover } from "./month-picker-popover";
 
 interface SummaryCardProps {
   summary: MonthSummary;
   payers: PayerRow[];
   monthName: string;
   trend?: MonthChange;
+  currentMonth?: string;
+  onMonthChange?: (month: string) => void;
 }
 
 // Assign colors to payers based on index
 const payerColors = ["lavender", "warning", "mint", "blue"] as const;
 
-export function SummaryCard({ summary, payers, monthName, trend }: SummaryCardProps) {
+export function SummaryCard({ summary, payers, monthName, trend, currentMonth, onMonthChange }: SummaryCardProps) {
   const { kronor, ore } = formatSEKParts(summary.grandTotal);
 
   // Determine trend display
@@ -56,14 +59,36 @@ export function SummaryCard({ summary, payers, monthName, trend }: SummaryCardPr
         {/* Main total */}
         <div className="flex flex-col gap-1">
           <div className="flex items-center gap-2 mb-2">
-            <span className="p-1.5 bg-white/40 rounded-full flex items-center justify-center">
-              <span className="material-symbols-outlined text-sm text-charcoal-text/70">
-                calendar_today
-              </span>
-            </span>
-            <span className="text-sm font-bold uppercase tracking-wider text-charcoal-text/60">
-              {monthName} Spending
-            </span>
+            {currentMonth && onMonthChange ? (
+              <MonthPickerPopover
+                currentMonth={currentMonth}
+                onSelectMonth={onMonthChange}
+                align="left"
+                trigger={
+                  <div className="flex items-center gap-2 p-1 -m-1">
+                    <span className="p-1.5 bg-white/40 rounded-full flex items-center justify-center group-hover:bg-white/60 transition-colors">
+                      <span className="material-symbols-outlined text-sm text-charcoal-text/70">
+                        calendar_today
+                      </span>
+                    </span>
+                    <span className="text-sm font-bold uppercase tracking-wider text-charcoal-text/60">
+                      {monthName} Spending
+                    </span>
+                  </div>
+                }
+              />
+            ) : (
+              <>
+                <span className="p-1.5 bg-white/40 rounded-full flex items-center justify-center">
+                  <span className="material-symbols-outlined text-sm text-charcoal-text/70">
+                    calendar_today
+                  </span>
+                </span>
+                <span className="text-sm font-bold uppercase tracking-wider text-charcoal-text/60">
+                  {monthName} Spending
+                </span>
+              </>
+            )}
           </div>
           <h2 className="text-5xl font-black text-charcoal-text tracking-tight">
             {kronor}

--- a/apps/web/src/components/ui/input.tsx
+++ b/apps/web/src/components/ui/input.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, type InputHTMLAttributes } from "react";
 
-export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {}
+export type InputProps = InputHTMLAttributes<HTMLInputElement>;
 
 export const Input = forwardRef<HTMLInputElement, InputProps>(
   ({ className = "", ...props }, ref) => {

--- a/apps/web/src/components/ui/label.tsx
+++ b/apps/web/src/components/ui/label.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, type LabelHTMLAttributes } from "react";
 
-export interface LabelProps extends LabelHTMLAttributes<HTMLLabelElement> {}
+export type LabelProps = LabelHTMLAttributes<HTMLLabelElement>;
 
 export const Label = forwardRef<HTMLLabelElement, LabelProps>(
   ({ className = "", ...props }, ref) => {

--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, type SelectHTMLAttributes } from "react";
 
-export interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement> {}
+export type SelectProps = SelectHTMLAttributes<HTMLSelectElement>;
 
 export const Select = forwardRef<HTMLSelectElement, SelectProps>(
   ({ className = "", children, ...props }, ref) => {


### PR DESCRIPTION
## Summary
- Add MonthPickerPopover for interactive month selection on dashboard and reports
- Make calendar icon in SummaryCard and month pill in PayerBalanceCard clickable
- Add mobile bottom navigation between Dashboard, Expenses, and Reports pages
- Remove FAB variant from AddExpenseButton
- Fix various lint errors (useCallback, empty interfaces, setState in effect)

## Test plan
- [ ] Verify month picker opens on calendar icon click in SummaryCard
- [ ] Verify month picker opens on month pill click in PayerBalanceCard  
- [ ] Verify bottom nav appears on mobile viewport and navigates correctly
- [ ] Verify "Log Expense" button in WelcomeSection still opens modal
- [x] Verify build passes

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added mobile bottom navigation bar for streamlined menu access on small screens
  * Introduced interactive month picker for flexible date navigation throughout the app

* **Improvements**
  * Enhanced responsive layout optimized for mobile viewing
  * Improved month-to-month navigation in dashboard and reports
  * Better user experience for date selection across pages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->